### PR TITLE
Add `--precheck-connections` option

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -64,6 +64,7 @@ jobs:
               --single-group-size 1000 \
               --workers 1 \
               --output seeds \
+              --precheck-connections \
               > filenames.json
           fi
 

--- a/src/edgi_wm_crawler/__init__.py
+++ b/src/edgi_wm_crawler/__init__.py
@@ -1,8 +1,17 @@
+from concurrent.futures import as_completed, ThreadPoolExecutor
+from datetime import datetime, timezone
 from itertools import batched
 import json
 from pathlib import Path
 from sys import exit, stderr
-from .seeds import active_urls, format_text, format_browsertrix, group_urls
+from typing import Iterable
+from .seeds import (
+    active_urls,
+    check_connection_error,
+    format_text,
+    format_browsertrix,
+    group_urls,
+)
 
 
 def main() -> None:
@@ -27,6 +36,14 @@ def main() -> None:
         type=int,
         default=4,
         help='How many workers (browserstrix only).'
+    )
+    seeds_command.add_argument(
+        '--precheck-connections',
+        type=bool,
+        help=(
+            'Filter out hosts that are unreachable (DNS resolution errors, '
+            'connection timeouts, etc.).'
+        )
     )
     seeds_command.set_defaults(func=generate_seeds)
 
@@ -78,15 +95,25 @@ def main() -> None:
         default=Path('.'),
         help='Directory to write seed lists to.'
     )
+    multi_seeds_command.add_argument(
+        '--precheck-connections',
+        action='store_true',
+        help=(
+            'Filter out hosts that are unreachable (DNS resolution errors, '
+            'connection timeouts, etc.).'
+        )
+    )
     multi_seeds_command.set_defaults(func=generate_multi_seeds)
 
     args = parser.parse_args()
     args.func(**vars(args))
 
 
-def generate_seeds(*, format, pattern, workers, **_kwargs) -> None:
+def generate_seeds(*, format, pattern, workers, precheck_connections, **_kwargs) -> None:
     print(f'Generating seeds as {format}...', file=stderr)
     urls = active_urls(pattern=pattern)
+    if precheck_connections:
+        urls = filter_unreachable_hosts(urls)
     if format == 'text':
         print(format_text(urls))
     elif format == 'browsertrix':
@@ -96,7 +123,7 @@ def generate_seeds(*, format, pattern, workers, **_kwargs) -> None:
         exit(1)
 
 
-def generate_multi_seeds(*, pattern, workers: int, output: Path, size: int, single_group_size: int = 0, **_kwargs) -> None:
+def generate_multi_seeds(*, pattern, workers: int, output: Path, size: int, single_group_size: int = 0, precheck_connections: bool, **_kwargs) -> None:
     single_group_size = single_group_size or size
 
     print(f'Writing seed files to "{output}/*"...', file=stderr)
@@ -106,6 +133,8 @@ def generate_multi_seeds(*, pattern, workers: int, output: Path, size: int, sing
     files = []
 
     urls = active_urls(pattern=pattern)
+    if precheck_connections:
+        urls = filter_unreachable_hosts(urls, output_dir=output)
     core_groups = group_urls(urls, by='domain')
 
     oversized = [k for k, v in core_groups.items() if len(v) >= size]
@@ -141,3 +170,38 @@ def generate_multi_seeds(*, pattern, workers: int, output: Path, size: int, sing
             print(f'Wrote "{file.name}"', file=stderr)
 
     print(json.dumps([f.split('.seeds')[0] for f in files]))
+
+
+def filter_unreachable_hosts(urls: Iterable[str], output_dir: Path | None = None) -> list[str]:
+    host_groups = group_urls(urls, by='host')
+
+    print(f'Pre-checking {len(host_groups)} hosts for connection failures...', file=stderr)
+
+    urls = []
+    log_data = {}
+    with ThreadPoolExecutor(max_workers=5) as executor:
+        host_futures = {
+            executor.submit(check_connection_error, host_urls[0]): host
+            for host, host_urls in host_groups.items()
+        }
+        for future in as_completed(host_futures):
+            host = host_futures[future]
+            error = future.result()
+            log_data[host] = {
+                'timestamp': datetime.now(tz=timezone.utc).isoformat().replace('+00:00', 'Z'),
+                'error': error,
+                'urls': [],
+            }
+            if error:
+                print(f'❌ {host} (Error: {error})', file=stderr)
+                log_data[host]['urls'] = host_groups[host]
+            else:
+                print(f'✅ {host}', file=stderr)
+                urls.extend(host_groups[host])
+
+    if output_dir:
+        log_path = output_dir / 'precheck.log.json'
+        with log_path.open('w') as log_file:
+            json.dump(log_data, log_file)
+
+    return urls


### PR DESCRIPTION
Passing `--precheck-connections` when generating seeds will cause one URL from each hostname in the seed set to be requested and checked for connection errors before outputting seeds. URLs at hostnames that appear to be unreachable (right now, that's DNS resolution failures or timing out on the connection) will be stripped from the seed list. A `precheck.log.json` file will be output along with the seeds that contains information about what hostnames were unreachable so other tools can later record it in our DB or wherever.

This is mainly meant to work around problems like we had this weekend, where a whole bunch of epa.gov subdomains went offline, causing our crawls to slow down so much that they got cancelled for running too long. This avoids checking such URLs in the first place. It also gives us a convenient place to start automatically recording connection failures in the DB (we added the ability to record them near the start of 2025, but have been putting them in manually based on logs in exceptional situations).

Ideally browsertrix-crawler might do something like this as it crawls (so we don't waste a lot of time double-checking so many URLs before we even start the crawl proper), but it's definitely an edge case for them. Not sure if they'd want to bake it in (see https://github.com/webrecorder/browsertrix-crawler/issues/879).