### PR TITLE
Allow crawling specific URL(s) on demand

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -15,6 +15,10 @@ on:
         description: 'Use test seeds'
         type: boolean
         default: true
+      url_pattern:
+        description: 'URL pattern to crawl (if not using test seeds)'
+        type: string
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -63,6 +67,7 @@ jobs:
             echo '["test"]' > filenames.json
           else
             uv run edgi-wm-crawler multi-seeds \
+              --pattern '${{ inputs.url_pattern || '' }}' \
               --size 250 \
               --single-group-size 1000 \
               --workers 1 \


### PR DESCRIPTION
This adds a parameter to the crawl workflow that allows you to specify a URL pattern (e.g. `https://earth.gov/us/*`) in order to limit the crawl to pages in our database that match the pattern. Useful for one-off, focused, time-sensitive crawls of specific URLs or sites.