### PR TITLE
Try skipping autoscroll in browsertrix v1.9.0

### DIFF
--- a/src/edgi_wm_crawler/seeds.py
+++ b/src/edgi_wm_crawler/seeds.py
@@ -104,6 +104,16 @@ def format_browsertrix(urls: Iterable[str], *, workers: int = 4, **options: Any)
         'rolloverSize': 8_000_000_000,
         # Default timeout is 90, bump it up for some sites that seem to have long CloudFront timeouts.
         'pageLoadTimeout': 120,
+        # FIXME: decide whether to keep skipping autoscroll. In v1.8.1, autoscroll was buggy, and didn't
+        # work on some big pages, making them finish artifically fast. In v1.9.0, it works, but on those
+        # big pages slows things down to a problematic degree.
+        # Use default behaviors *except* autoscroll.
+        'behaviors': [
+            # 'autoscroll',
+            'autoplay',
+            'autofetch',
+            'siteSpecific',
+        ],
         **options,
         'warcinfo': {
             'operator': '"Environmental Data & Governance Initiative" <contact@envirodatagov.org>',


### PR DESCRIPTION
See https://github.com/webrecorder/browsertrix-crawler/issues/913 for deeper exploration/discussion.

It looks like autoscroll was buggy in browsertrix-crawler v1.8.1, and didn’t run on some (large?) pages. In v1.9.0, it does run, and can take a *really* long time on a sufficiently long page.

This tests out disabling autoscroll altogether to see how that affects things.