### PR TITLE
Upgrade browertrix-crawler to v1.9.2

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  BROWSERTRIX_IMAGE: 'webrecorder/browsertrix-crawler:1.9.1'
+  BROWSERTRIX_IMAGE: 'webrecorder/browsertrix-crawler:1.9.2'
   COLLECTION_NAME_BASE: 'edgi-active-urls'
   COLLECTION_TITLE_BASE: 'EDGI Web Monitoring Crawl'
 

--- a/crawl-lib.sh
+++ b/crawl-lib.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-BROWSERTRIX_IMAGE="${BROWSERTRIX_IMAGE:-webrecorder/browsertrix-crawler:1.9.1}"
+BROWSERTRIX_IMAGE="${BROWSERTRIX_IMAGE:-webrecorder/browsertrix-crawler:1.9.2}"
 
 # Any preliminary stuff we want to make sure is done before starting a crawl.
 function prepare() {


### PR DESCRIPTION
This includes some follow-on changes to further address the slowdowns we noticed in 1.9.0 on epa.gov URLs. Release notes: https://github.com/webrecorder/browsertrix-crawler/releases/tag/v1.9.2