### PR TITLE
Reapply "Use timezone for scheduled crawl workflow (#62)" (#64)

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -3,7 +3,9 @@ name: Crawl
 on:
   schedule:
     # 5:30pm Pacific on M/W/F
-    - cron: '30 0 * * 2,4,6'
+    # Meant to be after the end of the business day in continental USA.
+    - cron: '30 17 * * 2,4,6'
+      timezone: 'America/Los_Angeles'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This reverts commit deae5e2d2eb4c3777d8d1b6485b7936ef065a5b8 and effectively re-applies #62. The timezones + workflow dispatch problem has supposedly been fixed.