### PR TITLE
Fix day of week in crawl schedule

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     # 5:30pm Pacific on M/W/F
     # Meant to be after the end of the business day in continental USA.
-    - cron: '30 17 * * 2,4,6'
+    - cron: '30 17 * * 1,3,5'
       timezone: 'America/Los_Angeles'
 
   workflow_dispatch:


### PR DESCRIPTION
In #62 and #67, I messed up the schedule by updating the time of day to match the current time zone, but forgetting to update the day of week. When the time was in UTC, everything happened on the next day. Now that the times are in a North American timezone, the day of week needs to be shifted back.