### PR TITLE
Add SENTRY_DSN to production crawl config

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -85,6 +85,7 @@ jobs:
           WEB_MONITORING_DB_EMAIL: '${{ secrets.WEB_MONITORING_DB_EMAIL }}'
           WEB_MONITORING_DB_PASSWORD: '${{ secrets.WEB_MONITORING_DB_PASSWORD }}'
           TAG_OPTIONS: ${{ inputs.tag && format('--tag ''{0}''', inputs.tag) || '' }}
+          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN }}
         run: |
           if [[ -n '${{ inputs.test_seeds && 'test' || '' }}' ]]; then
             mkdir -p seeds
@@ -116,6 +117,7 @@ jobs:
         env:
           WEB_MONITORING_DB_EMAIL: '${{ secrets.WEB_MONITORING_DB_EMAIL }}'
           WEB_MONITORING_DB_PASSWORD: '${{ secrets.WEB_MONITORING_DB_PASSWORD }}'
+          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN }}
         run: |
           uv run edgi-wm-crawler import-precheck seeds
 
@@ -206,6 +208,7 @@ jobs:
           WEB_MONITORING_DB_PASSWORD: '${{ secrets.WEB_MONITORING_DB_PASSWORD }}'
           WEB_MONITORING_DB_S3_BUCKET: '${{ secrets.WEB_MONITORING_DB_S3_BUCKET }}'
           DRY_RUN_OPTION: ${{ env.SAVE_RESULTS == 'false' && '--dry-run' || '' }}
+          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN }}
         run: |
           crawl_path="crawls/collections/${COLLECTION}"
           uv run wm-warc-import \


### PR DESCRIPTION
When running our Python tooling around crawls, we now set `SENTRY_DSN` when we are not doing a dry run, so errors can get sent back to Sentry.

Fixes #16.