### PR TITLE
Match Dependabot config to Renovate

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,19 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'uv'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 1


### PR DESCRIPTION
This updates the schedules and cooldown timeframes in our Dependabot config to match what I just configured for Renovate in #95 (I am going to try the two side-by-side here for a month or two).

This also covers this repo's part of edgi-govdata-archiving/web-monitoring#201