### PR TITLE
Only treat 429 as a rate limiting status code

### DIFF
--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -85,7 +85,7 @@ jobs:
           WEB_MONITORING_DB_EMAIL: '${{ secrets.WEB_MONITORING_DB_EMAIL }}'
           WEB_MONITORING_DB_PASSWORD: '${{ secrets.WEB_MONITORING_DB_PASSWORD }}'
           TAG_OPTIONS: ${{ inputs.tag && format('--tag ''{0}''', inputs.tag) || '' }}
-          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN }}
+          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN || '' }}
         run: |
           if [[ -n '${{ inputs.test_seeds && 'test' || '' }}' ]]; then
             mkdir -p seeds
@@ -117,7 +117,7 @@ jobs:
         env:
           WEB_MONITORING_DB_EMAIL: '${{ secrets.WEB_MONITORING_DB_EMAIL }}'
           WEB_MONITORING_DB_PASSWORD: '${{ secrets.WEB_MONITORING_DB_PASSWORD }}'
-          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN }}
+          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN || '' }}
         run: |
           uv run edgi-wm-crawler import-precheck seeds
 
@@ -208,7 +208,7 @@ jobs:
           WEB_MONITORING_DB_PASSWORD: '${{ secrets.WEB_MONITORING_DB_PASSWORD }}'
           WEB_MONITORING_DB_S3_BUCKET: '${{ secrets.WEB_MONITORING_DB_S3_BUCKET }}'
           DRY_RUN_OPTION: ${{ env.SAVE_RESULTS != 'true' && '--dry-run' || '' }}
-          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN }}
+          SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN || '' }}
         run: |
           crawl_path="crawls/collections/${COLLECTION}"
           uv run wm-warc-import \

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -202,12 +202,12 @@ jobs:
           retention-days: 7
 
       - name: Import to web-monitoring-db
-        if: ${{ success() && env.SAVE_RESULTS == 'true' }}
+        if: ${{ success() }}
         env:
           WEB_MONITORING_DB_EMAIL: '${{ secrets.WEB_MONITORING_DB_EMAIL }}'
           WEB_MONITORING_DB_PASSWORD: '${{ secrets.WEB_MONITORING_DB_PASSWORD }}'
           WEB_MONITORING_DB_S3_BUCKET: '${{ secrets.WEB_MONITORING_DB_S3_BUCKET }}'
-          DRY_RUN_OPTION: ${{ env.SAVE_RESULTS == 'false' && '--dry-run' || '' }}
+          DRY_RUN_OPTION: ${{ env.SAVE_RESULTS != 'true' && '--dry-run' || '' }}
           SENTRY_DSN: ${{ env.SAVE_RESULTS == 'true' && secrets.SENTRY_DSN }}
         run: |
           crawl_path="crawls/collections/${COLLECTION}"

--- a/src/edgi_wm_crawler/seeds.py
+++ b/src/edgi_wm_crawler/seeds.py
@@ -108,6 +108,7 @@ def format_browsertrix(urls: Iterable[str], *, workers: int = 4, **options: Any)
         'rolloverSize': 8_000_000_000,
         # Default timeout is 90, bump it up for some sites that seem to have long CloudFront timeouts.
         'pageLoadTimeout': 120,
+        'rateLimitStatusCodes': [429],
         **options,
         'warcinfo': {
             'operator': '"Environmental Data & Governance Initiative" <contact@envirodatagov.org>',


### PR DESCRIPTION
Browsertrix-crawler v1.14.0 added rate limiting detection, but it unfortunately treats 403 and 503 status codes as rate limits. We record a *huge* number of URLs that respond with those status codes (especially 403) and that are not rate limits, and it turns out that those pages have not been getting recorded since we upgraded.

This configures Browsertrix-crawler to only treat 429 (which is unambiguous) as a rate limit.

Browsertrix rate limit docs: https://crawler.docs.browsertrix.com/user-guide/rate-limits/