### PR TITLE
Handle Browsertrix fragment URL bug

### DIFF
--- a/src/edgi_wm_crawler/seeds.py
+++ b/src/edgi_wm_crawler/seeds.py
@@ -95,7 +95,11 @@ def format_browsertrix(urls: Iterable[str], *, workers: int = 4, **options: Any)
         if '#' in url:
             seeds.append({
                 'url': url,
-                'scopeType': 'page-spa',
+                # This *should* be `scopeType: page-spa`, so that we can record
+                # muliple fragment URLs of a given base, but there is a bug
+                # with it in Browsertrix v1.14.0:
+                # https://github.com/webrecorder/browsertrix-crawler/issues/1129
+                'scopeType': 'prefix',
                 'depth': 0
             })
         else:


### PR DESCRIPTION
We upgraded to Browsertrix 1.14.0 on Friday (#100), but it has a bug where fragment URLs in `page` and `page-spa` scope types fail to get recorded. They're working on a fix, but for now, we can work around it by using a `prefix` scope instead. (I checked that we are not currently monitoring multiple fragments at any given base URL, so this should be OK for now.)

For more, see https://github.com/webrecorder/browsertrix-crawler/issues/1129.