### PR TITLE
Consider connection refused to be a host down

### DIFF
--- a/src/edgi_wm_crawler/seeds.py
+++ b/src/edgi_wm_crawler/seeds.py
@@ -187,6 +187,8 @@ def check_connection_error(url: str) -> str | None:
             return 'timeout'
         elif 'RemoteDisconnected' in message:
             return 'ERR_CONNECTION_RESET'
+        elif 'Connection refused' in message:
+            return 'ERR_CONNECTION_REFUSED'
         else:
             # Ignore other types of connection errors, e.g. SSL failures, which
             # browsers (and our crawler) may handle less strictly.


### PR DESCRIPTION
We've avoided considering "connection refused" errors to be dead hosts because it *seems* like a pretty general error and likely to be the result of WAF or other blocking behavior. We also didn't really have any real example cases at the time connection pre-checking was added.

However, we have two hosts that started having this error on Friday and that we didn't faithfully record as network errors as a result. They are both legitimately down, and no other hosts we are monitoring give us this error. So it looks like this is unlikely to be a false positive, and should get considered as an unconnectable host.

The two hosts in question are:
- lasso.epa.gov
- foiapublicaccessportal.epa.gov